### PR TITLE
lang: Implement lossless strings

### DIFF
--- a/src/lang/eval/eval.rs
+++ b/src/lang/eval/eval.rs
@@ -450,13 +450,6 @@ impl<'a> Eval<'a> {
 
                 Ok(Value::String(format!("{}", expr)))
             }
-            f @ Function::Esc => {
-                ensure!(args.len() == 1, "{}() requires 1 argument", f);
-                let expr = self.eval_expr(&args[0])?;
-                let s = expr.as_string()?;
-
-                Ok(Value::String(format!("{}", s.escape_default())))
-            }
         }
     }
 
@@ -784,10 +777,6 @@ impl<'a> Eval<'a> {
                 "Returns a histogram (an array that `print()` will format)",
             ),
             ("str(expr)", "Returns `expr` in string representation"),
-            (
-                "esc(string)",
-                "Returns a string with non-ascii characters in `string` escaped",
-            ),
         ];
 
         let width = help
@@ -1185,44 +1174,5 @@ fn test_function_str() {
             String::from_utf8(output).expect("Output not utf-8"),
             expected
         );
-    }
-}
-
-#[test]
-fn test_function_esc() {
-    {
-        let tests = vec![
-            (r#"print esc("1\t2");"#, "1\\t2\n".to_string()),
-            (r#"print esc("1\\t2");"#, "1\\\\t2\n".to_string()),
-            (r#"print esc("1 2");"#, "1 2\n".to_string()),
-            (r#"print esc("1 2\n");"#, "1 2\\n\n".to_string()),
-        ];
-
-        use crate::lang::parse::parse;
-        for (input, expected) in tests {
-            let mut output = Vec::new();
-            let mut eval = Eval::new(&mut output, false);
-            match eval.eval(&parse(input).expect("Failed to parse")) {
-                EvalResult::Ok => (),
-                _ => assert!(false, "Failed to eval input"),
-            };
-            assert_eq!(
-                String::from_utf8(output).expect("Output not utf-8"),
-                expected
-            );
-        }
-    }
-    {
-        let tests = vec![(r#"esc(1);"#), (r#"esc(hist());"#), (r#"esc();"#)];
-
-        use crate::lang::parse::parse;
-        for input in tests {
-            let mut output = Vec::new();
-            let mut eval = Eval::new(&mut output, false);
-            match eval.eval(&parse(input).expect("Failed to parse")) {
-                EvalResult::Err(_) => (),
-                _ => assert!(false, "Eval succeeded when should have failed"),
-            };
-        }
     }
 }

--- a/src/lang/functions.rs
+++ b/src/lang/functions.rs
@@ -11,7 +11,6 @@ pub enum Function {
     Len,
     Hist,
     Str,
-    Esc,
 }
 
 impl fmt::Display for Function {
@@ -24,7 +23,6 @@ impl fmt::Display for Function {
             Function::Len => write!(f, "len"),
             Function::Hist => write!(f, "hist"),
             Function::Str => write!(f, "str"),
-            Function::Esc => write!(f, "esc"),
         }
     }
 }
@@ -38,6 +36,5 @@ lazy_static! {
         Function::Len,
         Function::Hist,
         Function::Str,
-        Function::Esc,
     ];
 }


### PR DESCRIPTION
This commit backs the `Value::String` type with an array of `u8`s
instead of `std::string::String`. `std::string::String`s must be utf-8.
This is a problem for on-disk btrfs "strings", as those strings can be
an arbitrary array of non-nul bytes.

After this commit, we will have lossless strings. The rules with
lossless strings are as follows:

* When a string is printed in an aggregate (eg. a struct), each each
  byte will be escaped with
  https://doc.rust-lang.org/stable/std/ascii/fn.escape_default.html .

* When a string is directly printed (eg. `print "mystr\n"`), whitespace
  formatting will be applied. IOW, whitespace escape sequences will be
  passed directly to the output stream.

Note that we choose to implement lossless strings instead of treating
on-disk strings as `Value::Array` of u8 bytes because most of the time
the on-disk strings are still human readable. And since this language is
tailored to btrfs, this is a reasonable tradeoff.