### PR TITLE
btrfs: add BTRFS_DIR_INDEX_KEY struct definition

### DIFF
--- a/src/btrfs/definitions.rs
+++ b/src/btrfs/definitions.rs
@@ -980,7 +980,7 @@ lazy_static! {
         },
         Struct {
             name: "btrfs_dir_item",
-            key_match: |_, ty, _| ty == BTRFS_DIR_ITEM_KEY || ty == BTRFS_XATTR_ITEM_KEY,
+            key_match: |_, ty, _| ty == BTRFS_DIR_ITEM_KEY || ty == BTRFS_DIR_INDEX_KEY || ty == BTRFS_XATTR_ITEM_KEY,
             fields: vec![
                 Field {
                     name: Some("location"),


### PR DESCRIPTION
I'm getting these warnings:

  Warning: failed to find a matching on-disk struct for key [256, 96, 3]

96 is BTRFS_DIR_INDEX_KEY, which also uses struct btrfs_dir_item.