### PR TITLE
Fix shared extent handling

### DIFF
--- a/src/btrfs/definitions.rs
+++ b/src/btrfs/definitions.rs
@@ -872,11 +872,15 @@ lazy_static! {
                             offset += BTRFS_EXTENT_DATA_REF.size();
                         } else if ty == BTRFS_SHARED_DATA_REF_KEY {
                             inline_ref.fields.push(Field {
+                                name: Some("offset"),
+                                ty: Type::U64,
+                            });
+                            offset += 8;
+                            inline_ref.fields.push(Field {
                                 name: Some("shared_data_ref"),
                                 ty: Type::Struct(BTRFS_SHARED_DATA_REF.clone()),
                             });
                             offset += BTRFS_SHARED_DATA_REF.size();
-                            offset += 8;
                         } else if ty == BTRFS_SHARED_BLOCK_REF_KEY || ty == BTRFS_TREE_BLOCK_REF_KEY {
                             inline_ref.fields.push(Field {
                                 name: Some("offset"),

--- a/src/btrfs/definitions.rs
+++ b/src/btrfs/definitions.rs
@@ -643,12 +643,8 @@ lazy_static! {
         key_match: |_, _, _| false,
         fields: vec![
             Field {
-                name: Some("type"),
-                ty: Type::U8,
-            },
-            Field {
-                name: Some("offset"),
-                ty: Type::U64,
+                name: Some("count"),
+                ty: Type::U32,
             },
         ],
     };
@@ -880,6 +876,7 @@ lazy_static! {
                                 ty: Type::Struct(BTRFS_SHARED_DATA_REF.clone()),
                             });
                             offset += BTRFS_SHARED_DATA_REF.size();
+                            offset += 8;
                         } else if ty == BTRFS_SHARED_BLOCK_REF_KEY || ty == BTRFS_TREE_BLOCK_REF_KEY {
                             inline_ref.fields.push(Field {
                                 name: Some("offset"),


### PR DESCRIPTION
There are two problems with the shared extent handling

1. The definition for `btrfs_shared_data_ref` was incorrect, it needed to only have a u32 for count.  This made the math wrong as we walked through the leaf.  In addition to that we weren't taking into account the size of the offset portion of the inline ref, again messing up the offset calculation.
2. We weren't getting the offset for `btrfs_shared_data_ref`, so it made the count appear incorrect.  Fix this by push the offset from the inline extent properly, so we get the proper output.  The following script

```
(btrd) filesystem "/mnt/test"
(btrd) k = key(0, BTRFS_BLOCK_GROUP_ITEM_KEY, 0, 0)
(btrd) k.max_type = BTRFS_BLOCK_GROUP_ITEM_KEY
(btrd) bgs = search(BTRFS_EXTENT_TREE_OBJECTID, k)
(btrd) bgs
```

now generates the correct output for a shared data ref

```
    struct btrfs_extent_item {
        .refs = 1,
        .generation = 7,
        .flags = 1,
        .inline_ref = struct btrfs_extent_inline_ref {
            .type = 184,
            .offset = 7028736,
            .shared_data_ref = struct btrfs_shared_data_ref {
                .count = 1,
            },
        },
    },
```

Whereas before it would error out, and then once the error was fixed it would print the improper count.